### PR TITLE
Secure ArgoCD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ __marimo__/
 # Ansible
 .ansible
 ansible.log
+
+# user only files
+vault.yml

--- a/deploy_app.yml
+++ b/deploy_app.yml
@@ -1,8 +1,10 @@
-- name: Configure Resources & Deploy App
+- name: Deploy App
   hosts:
     - target_host
   roles:
     - deploy_app
+  vars_files:
+    - vault.yml
   tasks:
     - name: Create Ingress to guestbook app.
       kubernetes.core.k8s:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ ansible-lint >= 25.8.1
 jmespath == 1.0.1
 jsonpatch == 1.33
 kubernetes >= 24.2.0
+passlib
 pyyaml >= 3.11

--- a/roles/deploy_app/tasks/main.yml
+++ b/roles/deploy_app/tasks/main.yml
@@ -1,22 +1,17 @@
 # ////////////////////////////////////////////
 # Handle Credentials
 # ////////////////////////////////////////////
-- name: Get Argo CD admin password from secret
-  command: >
-    kubectl -n argocd get secret argocd-initial-admin-secret
-    -o jsonpath="{.data.password}"
-  register: argocd_secret
 
-- name: Decode admin password
-  set_fact:
-    admin_password: "{{ argocd_secret.stdout | b64decode }}"
+- name: Get the hash of the initial password.
+  ansible.builtin.set_fact:
+    argocd_password_hashed: "{{ argocd_admin_password | password_hash('bcrypt') }}"
 
 - name: Login to Argo CD server
   command: >
     argocd login {{ argocd_server }}
     --username admin
-    --password {{ admin_password }}
-    {{ '--insecure' if argocd_insecure else '' }}
+    --password {{ argocd_admin_password }}
+    {{ '--insecure' if argocd_admin_password else '' }}
   changed_when: false
 
 # ////////////////////////////////////////////
@@ -60,3 +55,24 @@
   command: argocd app sync {{ app_name }}
   register: sync_result
   changed_when: "'Successfully synced' in sync_result.stdout"
+
+# ////////////////////////////////////////////
+# Verify app
+# ////////////////////////////////////////////
+- name: Wait for Application pods to be ready
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: "{{ dest_namespace }}"
+  register: app_pods
+  until: >
+    app_pods.resources
+    | json_query("[*].status.containerStatuses[].ready")
+    | select('equalto', true)
+    | list
+    | length == app_pods.resources | length
+  retries: 40
+  delay: 15
+
+- name: Show Application pod names
+  ansible.builtin.debug:
+    msg: "App pods: {{ app_pods.resources | map(attribute='metadata.name') | list }}"

--- a/roles/secure_argocd/tasks/main.yml
+++ b/roles/secure_argocd/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: Get the hash of the initial password.
+  ansible.builtin.set_fact:
+    argocd_password_hashed: "{{ argocd_admin_password | password_hash('bcrypt') }}"
+
+- name: Change ArgoCD admin password to secure it.
+  kubernetes.core.k8s:
+    state: present
+    namespace: argocd
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: argocd-secret
+      type: Opaque
+      stringData:
+        admin.password: "{{ argocd_password_hashed }}"
+        admin.passwordMtime: "{{ lookup('pipe', 'date +%FT%T%Z') }}"
+
+- name: Check if initial admin secret exists
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: argocd
+    name: argocd-initial-admin-secret
+  register: initial_secret
+  ignore_errors: true
+
+- name: Delete initial admin secret if it exists
+  kubernetes.core.k8s:
+    state: absent
+    namespace: argocd
+    kind: Secret
+    name: argocd-initial-admin-secret
+  when: initial_secret.resources | length > 0
+
+- name: Restart ArgoCD server pods
+  kubernetes.core.k8s:
+    state: absent
+    kind: Pod
+    namespace: argocd
+    label_selectors:
+      - app.kubernetes.io/name=argocd-server

--- a/secure_argocd.yml
+++ b/secure_argocd.yml
@@ -1,0 +1,7 @@
+- name: Secure ArgoCD
+  hosts:
+    - target_host
+  vars_files:
+    - vault.yml
+  roles:
+    - secure_argocd


### PR DESCRIPTION
1. Add a playbook which changes the argocd password to a pass stored in ansible-vault.
2. Update deploy_app playbook to use vault pass.
3. Update readme to direct user to secure argocd prior to running the deploy app playbook.